### PR TITLE
Support unicode in launchpad bug description

### DIFF
--- a/filch/constants.py
+++ b/filch/constants.py
@@ -38,7 +38,7 @@ definition: {definition_status}
 source: bp|{name}
 """
 
-BUG_CARD_DESC = """{description}
+BUG_CARD_DESC = u"""{description}
 
 bug_url: {web_link}
 information_type: {information_type}


### PR DESCRIPTION
Since the format string is defined as a simple string, an attempt to
expand it with a unicode value results in UnicodeEncodeError.

This patch makes the format string unicode, which should allow us to
pass non-ascii strings into it, including launchpad description.