### PR TITLE
Fix fetching the first bugzilla config option

### DIFF
--- a/filch/importer.py
+++ b/filch/importer.py
@@ -134,7 +134,7 @@ def importer(service, id, url, host, user, password, project, board,
                            "password arguments.")
                 sys.exit(1)
             else:
-                host = config['bugzilla'].keys()[0]
+                host = list(config['bugzilla'].keys())[0]
 
         url = config['bugzilla'][host]['url']
         user = config['bugzilla'][host]['user']


### PR DESCRIPTION
On Python 3 .keys returns a key view, this is more like a set doesn't
support indexing. This can be solved by explicitly converting to a list.

```
$ python2
Python 2.7.13 (default, Mar 31 2017, 08:44:09) 
[GCC 6.3.1 20161221 (Red Hat 6.3.1-1)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> {"a":1}.keys()[0]
'a'
>>> 
$ python
Python 3.6.1 (default, Mar 31 2017, 08:38:36) 
[GCC 6.3.1 20161221 (Red Hat 6.3.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> {"a":1}.keys()[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'dict_keys' object does not support indexing
>>> list({"a":1}.keys())[0]
'a'
>>> 
```