### PR TITLE
Add support to import StoryBoard stories

### DIFF
--- a/filch/constants.py
+++ b/filch/constants.py
@@ -45,6 +45,13 @@ information_type: {information_type}
 source: bug|{id}
 """
 
+STORY_CARD_DESC = u"""{description}
+
+story_url: {story_url}
+status: {status}
+source: story|{id}
+"""
+
 BZ_CARD_DESC = u"""{description}
 
 bug_url: {weburl}

--- a/filch/importer.py
+++ b/filch/importer.py
@@ -116,6 +116,22 @@ def importer(service, id, url, host, user, password, project, board,
             click.echo(
                 'You have successfully imported "%s"' % bug['title'])
 
+    if service == 'story':
+        for story_id in list(id):
+            story = utils.get_storyboard_story(story_id)
+            cards.create_card(
+                trello_key,
+                trello_token,
+                board,
+                story['title'],
+                constants.STORY_CARD_DESC.format(**story),
+                card_labels=list(labels),
+                card_due="null",
+                list_name=list_name
+            )
+            click.echo(
+                'You have successfully imported "%s"' % story['title'])
+
     if service in ['bz', 'bugzilla']:
         if url:
             # also need user & password.  sslverify is optional

--- a/filch/utils.py
+++ b/filch/utils.py
@@ -36,6 +36,13 @@ def get_launchpad_bug(bug_id):
     return r.json()
 
 
+def get_storyboard_story(story_id):
+    url = 'https://storyboard.openstack.org/api/v1/stories/%s' % story_id
+    r = requests.get(url)
+    story = r.json()
+    story['story_url'] = url
+    return story
+
 def get_bz(bz_id, **kwargs):
     bz4 = bugzilla.Bugzilla44(
         url=kwargs['url'],
@@ -44,4 +51,3 @@ def get_bz(bz_id, **kwargs):
     )
 
     return bz4.getbug(bz_id)
-


### PR DESCRIPTION
OpenStack projects can migrate from Launchpad to StoryBoard [0], for
example Octavia made the move a few months ago. This adds support to
import stories, like with:
$ filch-import story --id 1646125

[0] https://docs.openstack.org/infra/storyboard/migration.html