### PR TITLE
Fix storyboard story URL in created cards

### DIFF
--- a/filch/utils.py
+++ b/filch/utils.py
@@ -42,7 +42,9 @@ def get_storyboard_story(story_id):
     url = 'https://storyboard.openstack.org/api/v1/stories/%s' % story_id
     r = requests.get(url)
     story = r.json()
-    story['story_url'] = url
+    story['story_url'] = (
+            'https://storyboard.openstack.org/#!/story/%s' %
+            story_id)
     return story
 
 


### PR DESCRIPTION
This actually pointed to the API URL, not the human-readable one